### PR TITLE
Fix pog and cut commands not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.log
 Cogs/__pycache__
 Cogger.py
+*.json

--- a/Cogs/Error.py
+++ b/Cogs/Error.py
@@ -76,10 +76,12 @@ class CommandErrorHandler(commands.Cog):
             # All other Errors not returned come here. And we can just print the default TraceBack.
             print(f'Ignoring exception in command {ctx.command}:', file=sys.stderr)
             traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
+            py_error = traceback.format_exception(type(error), error, error.__traceback__)
+            py_error = ''.join(py_error)
             channel = self.bot.get_channel(767416350552490025)
-            await channel.send(f'An error occured with command `{ctx.command}` in cog `{ctx.cog}`.\
+            await channel.send(f'An error occured with command `{ctx.command}` in cog `{ctx.cog.qualified_name}`.\
             \n The command was invoked in <#{ctx.channel.id}> by `{ctx.author}`.\nThe server this was invoked in was `{ctx.guild}`. \nJumplink to command execution: {ctx.message.jump_url} . \nException:')
-            await channel.send(f'```py\n{traceback.format_exception(type(error), error, error.__traceback__)}```')
+            await channel.send(f'```py\n{py_error}```')
             embed = discord.Embed(title="⚠ An error occurred ⚠", colour=discord.Colour.red(), description="An unexpected error has occured, this should never happen. I have sent details to mesub#0556.")
             await ctx.send(embed=embed)
 

--- a/Cogs/Fun.py
+++ b/Cogs/Fun.py
@@ -27,7 +27,7 @@ class Fun(commands.Cog):
                  await ctx.send(f"This time, I would say that you are {pog_level}% pog.")
          elif member.id == self.bot.user.id:
              await ctx.send("I am 100% pog. No question.")
-         elif member.id == self.bot_owner_id:
+         elif member.id == self.bot.owner_id:
                  await ctx.send("mesub is 100% pog! (As always 😉)")
          elif member.id == 242730576195354624:
                  await ctx.send("Auttaja is beyond pog 😍😍")
@@ -50,7 +50,7 @@ class Fun(commands.Cog):
              await ctx.send("Why would like your own cut silly.")
          elif member.id == self.bot.user.id:
              await ctx.send("Glad you like it! (What would you think would happen?)")
-         elif member.id == self.bot.owner_id:
+         elif member.id == self.bot.owner.id:
                  await ctx.send("Command exucution failed: mesub's cut cannot be liked.")
          elif member.id == 242730576195354624:
                 await ctx.send("I refuse to like Auttaja's cut.")

--- a/Cogs/Fun.py
+++ b/Cogs/Fun.py
@@ -50,7 +50,7 @@ class Fun(commands.Cog):
              await ctx.send("Why would like your own cut silly.")
          elif member.id == self.bot.user.id:
              await ctx.send("Glad you like it! (What would you think would happen?)")
-         elif member.id == self.bot.owner.id:
+         elif member.id == self.bot.owner_id:
                  await ctx.send("Command exucution failed: mesub's cut cannot be liked.")
          elif member.id == 242730576195354624:
                 await ctx.send("I refuse to like Auttaja's cut.")


### PR DESCRIPTION
A typo in one of the statements caused an attribute to not be found. This resulted in an error and the command was not usable.

This error has now been rectified.

There is also better formatting internally.